### PR TITLE
Dp24 grabfiles once

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -50,16 +50,18 @@ process {
     }
 
     withName: AUTOFILTER_AND_CHECK_ASSEMBLY {
-        publishDir      = [[
-            path: { "${params.outdir}/${meta.id}/" },
-            mode: params.publish_dir_mode,
-            pattern: "autofiltering_done_indicator_file.txt"
-        ],
-        [
-            path:   { "${params.outdir}/${meta.id}/autofilter/"},
-            mode:   params.publish_dir_mode,
-            pattern:["*.fasta", "*.txt", "*csv"]
-        ]]
+        publishDir      = [
+            [
+                path: { "${params.outdir}/${meta.id}/" },
+                mode: params.publish_dir_mode,
+                pattern: "autofiltering_done_indicator_file.txt"
+            ],
+            [
+                path:   { "${params.outdir}/${meta.id}/autofilter/"},
+                mode:   params.publish_dir_mode,
+                pattern:["*.fasta", "*.txt", "*csv"]
+            ]
+        ]
     }
 
     withName: ASCC_MERGE_TABLES {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -34,7 +34,7 @@ process {
         ]
     }
 
-    withName: "AUTOFILTER_AND_CHECK_ASSEMBLY|CREATE_BTK_DATASET|ORGANELLE_CONTAMINATION_RECOMMENDATIONS|FILTER_BARCODE|SUMMARISE_VECSCREEN_OUTPUT|MERGE_BTK_DATASETS" {
+    withName: "ORGANELLE_CONTAMINATION_RECOMMENDATIONS|FILTER_BARCODE|SUMMARISE_VECSCREEN_OUTPUT" {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/${task.process.tokenize(':')[-1].toLowerCase()}" },
             mode: params.publish_dir_mode
@@ -45,21 +45,40 @@ process {
     withName: "FCS_FCSADAPTOR_EUK|FCS_FCSADAPTOR_PROK" {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/FCS-adaptor" },
-            mode: params.publish_dir_mode,
+            mode: params.publish_dir_mode
         ]
     }
 
     withName: AUTOFILTER_AND_CHECK_ASSEMBLY {
-        publishDir      = [
-            path: { "${params.outdir}/" },
+        publishDir      = [[
+            path: { "${params.outdir}/${meta.id}/" },
             mode: params.publish_dir_mode,
             pattern: "autofiltering_done_indicator_file.txt"
-        ]
+        ],
+        [
+            path:   { "${params.outdir}/${meta.id}/autofilter/"},
+            mode:   params.publish_dir_mode,
+            pattern:["*.fasta", "*.txt", "*csv"]
+        ]]
     }
 
     withName: ASCC_MERGE_TABLES {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/ASCC-main-output" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
+    withName: MERGE_BTK_DATASETS {
+        publishDir  = [
+            path: { "${params.outdir}/${meta.id}/merged_tables/" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
+    withName: CREATE_BTK_DATASET {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/create_btk_dataset" },
             mode: params.publish_dir_mode
         ]
     }

--- a/main.nf
+++ b/main.nf
@@ -189,10 +189,9 @@ workflow {
         )
     ) {
         ch_grabbed_reads_path       = GrabFiles( params.reads_path )
+    } else {
+        ch_grabbed_reads_path       = []
     }
-    ch_grabbed_reads_path           = []
-
-
 
     //
     // WORKFLOW: Run main workflow for GENOMIC samples

--- a/main.nf
+++ b/main.nf
@@ -42,6 +42,7 @@ workflow SANGERTOL_ASCC_GENOMIC {
     include_steps
     exclude_steps
     fcs
+    reads
 
     main:
 
@@ -55,6 +56,7 @@ workflow SANGERTOL_ASCC_GENOMIC {
         include_steps,
         exclude_steps,
         fcs,
+        reads
     )
 }
 
@@ -69,6 +71,7 @@ workflow SANGERTOL_ASCC_ORGANELLAR {
     include_steps
     exclude_steps
     fcs
+    reads
 
     main:
 
@@ -81,6 +84,7 @@ workflow SANGERTOL_ASCC_ORGANELLAR {
         include_steps,
         exclude_steps,
         fcs,
+        reads
     )
 }
 /*
@@ -176,16 +180,16 @@ workflow {
     //
     // LOGIC: GETS PACBIO READ PATHS FROM READS_PATH IF (COVERAGE OR BTK SUBWORKFLOW IS ACTIVE) OR ALL
     //
-    // if (
-    //     (
-    //         (include_workflow_steps.contains('coverage') && !exclude_workflow_steps.contains("coverage")) ||
-    //         (include_workflow_steps.contains('btk_busco') && !exclude_workflow_steps.contains("btk_busco"))
-    //     ) || (
-    //         include_workflow_steps.contains('ALL') && !exclude_workflow_steps.contains("btk_busco") && !exclude_workflow_steps.contains("coverage")
-    //     )
-    // ) {
-    //     ch_grabbed_reads_path       = GrabFiles( params.reads_path )
-    // }
+    if (
+        (
+            (include_workflow_steps.contains('coverage') && !exclude_workflow_steps.contains("coverage")) ||
+            (include_workflow_steps.contains('btk_busco') && !exclude_workflow_steps.contains("btk_busco"))
+        ) || (
+            include_workflow_steps.contains('ALL') && !exclude_workflow_steps.contains("btk_busco") && !exclude_workflow_steps.contains("coverage")
+        )
+    ) {
+        ch_grabbed_reads_path       = GrabFiles( params.reads_path )
+    }
     ch_grabbed_reads_path           = []
 
 
@@ -200,7 +204,8 @@ workflow {
         MAIN_WORKFLOW_VALIDATE_TAXID.out.versions,
         params.include,
         params.exclude,
-        fcs_gx_database_path
+        fcs_gx_database_path,
+        ch_grabbed_reads_path
     )
 
 
@@ -237,7 +242,8 @@ workflow {
             MAIN_WORKFLOW_VALIDATE_TAXID.out.versions,
             organellar_include,
             organellar_exclude,
-            fcs_gx_database_path
+            fcs_gx_database_path,
+            ch_grabbed_reads_path
         )
     }
 

--- a/main.nf
+++ b/main.nf
@@ -186,6 +186,8 @@ workflow {
             (include_workflow_steps.contains('btk_busco') && !exclude_workflow_steps.contains("btk_busco"))
         ) || (
             include_workflow_steps.contains('ALL') && !exclude_workflow_steps.contains("btk_busco") && !exclude_workflow_steps.contains("coverage")
+        ) || (
+            include_workflow_steps.contains('ALL') && params.profile_name == 'test'
         )
     ) {
         ch_grabbed_reads_path       = GrabFiles( params.reads_path )

--- a/main.nf
+++ b/main.nf
@@ -195,6 +195,7 @@ workflow {
         ch_grabbed_reads_path       = []
     }
 
+
     //
     // WORKFLOW: Run main workflow for GENOMIC samples
     //
@@ -231,7 +232,6 @@ workflow {
     }
 
 
-
     //
     // WORKFLOW: Run main workflow for ORGANELLAR samples
     //
@@ -247,6 +247,7 @@ workflow {
             ch_grabbed_reads_path
         )
     }
+
 
     //
     // SUBWORKFLOW: Run completion tasks

--- a/nextflow.config
+++ b/nextflow.config
@@ -206,7 +206,10 @@ profiles {
         executor.cpus           = 4
         executor.memory         = 8.GB
     }
-    test      { includeConfig 'conf/test.config'      }
+    test      {
+        params.profile_name     = 'test'
+        includeConfig 'conf/test.config'
+    }
     test_full { includeConfig 'conf/test_full.config' }
 }
 

--- a/subworkflows/local/pacbio_barcode_check.nf
+++ b/subworkflows/local/pacbio_barcode_check.nf
@@ -13,7 +13,7 @@ include { FILTER_BARCODE         } from '../../modules/local/filter_barcode'
 workflow PACBIO_BARCODE_CHECK {
     take:
     reference_tuple         // tuple    [[meta.id], reference ]
-    pacbio_data             // tuple    [[meta.id], pacbio-files]
+    pacbio_data             // tuple    pacbio-files-folder
     pacbio_type             // val      (params.pacbio_type)
     barcodes_file           // tuple    [[meta.id], barcode-file]
     barcode_names           // val      (csv-list-string)

--- a/subworkflows/local/pe_mapping.nf
+++ b/subworkflows/local/pe_mapping.nf
@@ -4,33 +4,15 @@ include { SAMTOOLS_MERGE                            } from '../../modules/nf-cor
 workflow PE_MAPPING {
 
     take:
-    reference_tuple          // Channel [ val(meta), path(file) ]
-    pacbio_tuple             // Channel [ val(meta), val( str ) ]
-    reads_type               // Channel val( str )
+    reference_data_tuple     // Channel [ val(meta), path(file), path(file) ]
 
     main:
     ch_versions     = Channel.empty()
 
-
-    //
-    // LOGIC: GETS PACBIO READ PATHS FROM READS_PATH
-    //
-    ch_grabbed_reads_path       = GrabFiles( pacbio_tuple )
-
-    ch_grabbed_reads_path
-        .map { meta, files ->
-            tuple( files )
-        }
-        .flatten()
-        .set { ch_reads_path }
-
-
     //
     // LOGIC: MAKE MINIMAP INPUT CHANNEL
     //
-    reference_tuple
-        .combine( ch_reads_path )
-        .combine( reads_type )
+    reference_data_tuple
         .map { meta, ref, reads_path, reads_type ->
             tuple(
                 [   id          : meta.id,

--- a/subworkflows/local/run_fcsgx.nf
+++ b/subworkflows/local/run_fcsgx.nf
@@ -6,7 +6,6 @@ workflow RUN_FCSGX {
     take:
     reference               // Channel [ val(meta), path(file) ]
     fcsgxpath               // Channel path(file)
-    taxid                   // Channel val(taxid)
     ncbi_rankedlineage_path // Channel path(file)
 
     main:
@@ -14,29 +13,10 @@ workflow RUN_FCSGX {
 
 
     //
-    // LOGIC: Create input channel for FCS_FCSGX, taxid is required to be the meta id.
-    //
-    reference
-        .combine(
-            Channel.of(taxid)
-        )
-        .map { it ->
-                tuple (
-                        [
-                            id: it[0].id    // Meta.id
-                        ],
-                        it[2],              // TaxID
-                        it[1]               // RefFile
-                    )
-            }
-        .set { reference_with_taxid }
-
-
-    //
     // MODULE: FCSGX_RUNGX RUN ON ASSEMBLY FASTA TUPLE WITH THE TAXID AGAINST THE FCSGXDB
     //
     FCSGX_RUNGX (
-        reference_with_taxid,
+        reference,
         fcsgxpath,
         []
     )

--- a/subworkflows/local/run_read_coverage.nf
+++ b/subworkflows/local/run_read_coverage.nf
@@ -11,7 +11,6 @@ workflow RUN_READ_COVERAGE {
     take:
     reference_tuple          // Channel [ val(meta), path(file) ]
     reads
-    pacbio_data              // [Path(1), Path(2)...]
     platform                 // Channel val( str )
 
     main:
@@ -19,6 +18,11 @@ workflow RUN_READ_COVERAGE {
     ch_align_bam    = Channel.empty()
     ch_refer_bam    = Channel.empty()
 
+
+
+    reads.view{"READS: $it"}
+    reference_tuple.view{"REF: $it"}
+    println platform
 
     //
     // LOGIC: GETS PACBIO READ PATHS FROM READS_PATH

--- a/subworkflows/local/run_read_coverage.nf
+++ b/subworkflows/local/run_read_coverage.nf
@@ -10,6 +10,7 @@ workflow RUN_READ_COVERAGE {
 
     take:
     reference_tuple          // Channel [ val(meta), path(file) ]
+    reads
     pacbio_data              // [Path(1), Path(2)...]
     platform                 // Channel val( str )
 
@@ -22,9 +23,7 @@ workflow RUN_READ_COVERAGE {
     //
     // LOGIC: GETS PACBIO READ PATHS FROM READS_PATH
     //
-    ch_grabbed_reads_path       = GrabFiles( params.reads_path )
-
-    ch_grabbed_reads_path
+    reads
         .flatten()
         .set{ collection_of_reads }
 
@@ -122,17 +121,4 @@ workflow RUN_READ_COVERAGE {
     tsv_ch          = SAMTOOLS_DEPTH_AVERAGE_COVERAGE.out.average_coverage
     bam_ch          = SAMTOOLS_SORT.out.bam
     versions        = ch_versions.ifEmpty(null)
-}
-
-process GrabFiles {
-    tag "Grab PacBio Data"
-    executor 'local'
-
-    input:
-    path("in")
-
-    output:
-    path("in/*.{fa,fasta,fna}.{gz}")
-
-    "true"
 }

--- a/subworkflows/local/run_read_coverage.nf
+++ b/subworkflows/local/run_read_coverage.nf
@@ -18,9 +18,6 @@ workflow RUN_READ_COVERAGE {
     ch_align_bam    = Channel.empty()
     ch_refer_bam    = Channel.empty()
 
-    reads.view{"READS: $it"}
-    reference_tuple.view{"REF: $it"}
-    println platform
 
     //
     // LOGIC: GETS PACBIO READ PATHS FROM READS_PATH
@@ -33,6 +30,7 @@ workflow RUN_READ_COVERAGE {
         .combine(collection_of_reads)
         .set { ref_and_data }
         // [meta], ref, [reads]
+
 
     //
     // LOGIC: CHECK IF THE INPUT READ FILE IS PAIRED END OR SINGLE END BASED ON THE READ PLATFORM

--- a/subworkflows/local/run_read_coverage.nf
+++ b/subworkflows/local/run_read_coverage.nf
@@ -18,8 +18,6 @@ workflow RUN_READ_COVERAGE {
     ch_align_bam    = Channel.empty()
     ch_refer_bam    = Channel.empty()
 
-
-
     reads.view{"READS: $it"}
     reference_tuple.view{"REF: $it"}
     println platform

--- a/subworkflows/local/run_read_coverage.nf
+++ b/subworkflows/local/run_read_coverage.nf
@@ -37,15 +37,6 @@ workflow RUN_READ_COVERAGE {
     // - Removed the mix function from this as it is not needed, there shouldn't be multiple read
     // types
     //
-    reference_tuple
-        .map{meta, file ->
-            tuple(meta, pacbio_data)
-        }
-        .set { pacbio_tuple }
-
-    Channel
-        .of(platform)
-        .set {platform_type}
 
     if ( platform == "hifi" || platform == "clr" || platform == "ont" ) {
 
@@ -67,9 +58,7 @@ workflow RUN_READ_COVERAGE {
         // MODULE: RUN PAIRED END MAPPING ON THE REFERENCE AND LONGREAD DATA
         //
         PE_MAPPING  (
-            reference_tuple,
-            pacbio_tuple,
-            platform_type
+            ref_and_data
         )
         ch_versions = ch_versions.mix(PE_MAPPING.out.versions)
 

--- a/subworkflows/local/run_read_coverage.nf
+++ b/subworkflows/local/run_read_coverage.nf
@@ -30,6 +30,7 @@ workflow RUN_READ_COVERAGE {
     reference_tuple
         .combine(collection_of_reads)
         .set { ref_and_data }
+        // [meta], ref, [reads]
 
     //
     // LOGIC: CHECK IF THE INPUT READ FILE IS PAIRED END OR SINGLE END BASED ON THE READ PLATFORM

--- a/workflows/ascc_genomic.nf
+++ b/workflows/ascc_genomic.nf
@@ -50,6 +50,7 @@ workflow ASCC_GENOMIC {
     include_steps           // params.include_steps
     exclude_steps           // params.exclude_steps
     fcs_db                  // path(path)
+    reads
 
     main:
     ch_versions = Channel.empty()

--- a/workflows/ascc_genomic.nf
+++ b/workflows/ascc_genomic.nf
@@ -355,7 +355,6 @@ workflow ASCC_GENOMIC {
     //     RUN_READ_COVERAGE (
     //         reference_tuple_from_GG,
     //         reads,
-    //         params.reads_path,
     //         params.reads_type,
     //     )
     //     ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}

--- a/workflows/ascc_genomic.nf
+++ b/workflows/ascc_genomic.nf
@@ -349,21 +349,21 @@ workflow ASCC_GENOMIC {
     //
     // SUBWORKFLOW: CALCULATE AVERAGE READ COVERAGE
     //
-    // if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
-    //         !exclude_workflow_steps.contains("coverage")
-    // ) {
-    //     RUN_READ_COVERAGE (
-    //         reference_tuple_from_GG,
-    //         reads,
-    //         params.reads_type,
-    //     )
-    //     ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
-    //     ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
-    //     ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
-    // } else {
-    //     ch_coverage         = []
-    //     ch_bam              = []
-    // }
+    if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
+            !exclude_workflow_steps.contains("coverage")
+    ) {
+        RUN_READ_COVERAGE (
+            reference_tuple_from_GG,
+            reads,
+            params.reads_type,
+        )
+        ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
+        ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
+        ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
+    } else {
+        ch_coverage         = []
+        ch_bam              = []
+    }
 
     ch_coverage         = []
     ch_bam              = []

--- a/workflows/ascc_genomic.nf
+++ b/workflows/ascc_genomic.nf
@@ -349,23 +349,25 @@ workflow ASCC_GENOMIC {
     //
     // SUBWORKFLOW: CALCULATE AVERAGE READ COVERAGE
     //
-    if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
-            !exclude_workflow_steps.contains("coverage")
-    ) {
-        RUN_READ_COVERAGE (
-            reference_tuple_from_GG,
-            reads,
-            params.reads_path,
-            params.reads_type,
-        )
-        ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
-        ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
-        ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
-    } else {
-        ch_coverage         = []
-        ch_bam              = []
-    }
+    // if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
+    //         !exclude_workflow_steps.contains("coverage")
+    // ) {
+    //     RUN_READ_COVERAGE (
+    //         reference_tuple_from_GG,
+    //         reads,
+    //         params.reads_path,
+    //         params.reads_type,
+    //     )
+    //     ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
+    //     ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
+    //     ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
+    // } else {
+    //     ch_coverage         = []
+    //     ch_bam              = []
+    // }
 
+    ch_coverage         = []
+    ch_bam              = []
 
     //
     // SUBWORKFLOW: SCREENING FOR VECTOR SEQUENCE

--- a/workflows/ascc_organellar.nf
+++ b/workflows/ascc_organellar.nf
@@ -47,6 +47,7 @@ workflow ASCC_ORGANELLAR {
     include_steps           // params.include_steps
     exclude_steps           // params.exclude_steps
     fcs_db                  // path(file)
+    reads
 
     main:
     ch_versions = Channel.empty()

--- a/workflows/ascc_organellar.nf
+++ b/workflows/ascc_organellar.nf
@@ -187,7 +187,6 @@ workflow ASCC_ORGANELLAR {
         RUN_READ_COVERAGE (
             ESSENTIAL_JOBS.out.reference_tuple_from_GG, // Again should this be the validated fasta?
             reads,
-            params.reads_path,
             params.reads_type,
         )
         ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}

--- a/workflows/ascc_organellar.nf
+++ b/workflows/ascc_organellar.nf
@@ -242,128 +242,128 @@ workflow ASCC_ORGANELLAR {
     //
     // LOGIC: WE NEED TO MAKE SURE THAT THE INPUT SEQUENCE IS OF AT LEAST LENGTH OF params.seqkit_window
     //
-    ESSENTIAL_JOBS.out.reference_with_seqkit
-        //
-        // Here we are using the un-filtered genome, any filtering may (accidently) cause an empty fasta
-        //
-        .map{ meta, file ->
-            tuple(
-                [
-                    id: meta.id,
-                    sliding: meta.sliding,
-                    window: meta.window,
-                    seq_count: CountFastaLength(file)
-                ],
-                file
-            )
-        }
-        .filter { meta, file ->
-                    meta.seq_count >= params.seqkit_window
-        }
-        .set{ valid_length_fasta }
+    // ESSENTIAL_JOBS.out.reference_with_seqkit
+    //     //
+    //     // Here we are using the un-filtered genome, any filtering may (accidently) cause an empty fasta
+    //     //
+    //     .map{ meta, file ->
+    //         tuple(
+    //             [
+    //                 id: meta.id,
+    //                 sliding: meta.sliding,
+    //                 window: meta.window,
+    //                 seq_count: CountFastaLength(file)
+    //             ],
+    //             file
+    //         )
+    //     }
+    //     .filter { meta, file ->
+    //                 meta.seq_count >= params.seqkit_window
+    //     }
+    //     .set{ valid_length_fasta }
 
-    valid_length_fasta
-        .map{ meta, file ->
-            println "Running BLAST (NT, DIAMOND, NR) on VALID ORGANELLE: $meta --- $file"
-        }
+    // valid_length_fasta
+    //     .map{ meta, file ->
+    //         println "Running BLAST (NT, DIAMOND, NR) on VALID ORGANELLE: $meta --- $file"
+    //     }
 
-    //
-    // LOGIC: THIS CONDITIONAL SHOULD EXECUTE THE PROCESS WHEN:
-    //          INCLUDE STEPS ARE EITHER nt_blast AND all
-    //              _AS WELL AS_
-    //          EXCLUDE _NOT_ CONTAINING nt_blast AND THE valid_length_fasta IS NOT EMPTY
-    //
-    if ( (include_workflow_steps.contains('nt_blast') || include_workflow_steps.contains('ALL')) &&
-            !exclude_workflow_steps.contains("nt_blast") && !valid_length_fasta.ifEmpty(true)
-    ) {
-        //
-        // NOTE: ch_nt_blast needs to be set in two places incase it
-        //          fails during the run (This IS an expected outcome of this subworkflow)
-        //
-        ch_nt_blast         = []
-        ch_blast_lineage    = []
-
-
-        SUBWORKFLOW: EXTRACT RESULTS HITS FROM NT-BLAST
-
-        EXTRACT_NT_BLAST (
-            valid_length_fasta,
-            Channel.value(params.nt_database_path),
-            Channel.value(params.ncbi_accession_ids_folder),
-            Channel.value(params.ncbi_ranked_lineage_path)
-        )
-        ch_versions         = ch_versions.mix(EXTRACT_NT_BLAST.out.versions)
-        ch_nt_blast         = EXTRACT_NT_BLAST.out.ch_blast_hits.map{it[1]}
-        ch_blast_lineage    = EXTRACT_NT_BLAST.out.ch_top_lineages.map{it[1]}
-
-    } else {
-        ch_nt_blast         = Channel.empty()
-        ch_blast_lineage    = Channel.empty()
-    }
+    // //
+    // // LOGIC: THIS CONDITIONAL SHOULD EXECUTE THE PROCESS WHEN:
+    // //          INCLUDE STEPS ARE EITHER nt_blast AND all
+    // //              _AS WELL AS_
+    // //          EXCLUDE _NOT_ CONTAINING nt_blast AND THE valid_length_fasta IS NOT EMPTY
+    // //
+    // if ( (include_workflow_steps.contains('nt_blast') || include_workflow_steps.contains('ALL')) &&
+    //         !exclude_workflow_steps.contains("nt_blast") && !valid_length_fasta.ifEmpty(true)
+    // ) {
+    //     //
+    //     // NOTE: ch_nt_blast needs to be set in two places incase it
+    //     //          fails during the run (This IS an expected outcome of this subworkflow)
+    //     //
+    //     ch_nt_blast         = []
+    //     ch_blast_lineage    = []
 
 
-    //
-    // SUBWORKFLOW: DIAMOND BLAST FOR INPUT ASSEMBLY
-    //
-    if ( (include_workflow_steps.contains('nr_diamond') || include_workflow_steps.contains('ALL')) &&
-            !exclude_workflow_steps.contains("nr_diamond") && !valid_length_fasta.ifEmpty(true)
-    ) {
-        NR_DIAMOND (
-            valid_length_fasta,
-            params.diamond_nr_database_path
-        )
-        nr_full             = NR_DIAMOND.out.reformed.map{it[1]}
-        nr_hits             = NR_DIAMOND.out.hits_file.map{it[1]}
-        ch_versions         = ch_versions.mix(NR_DIAMOND.out.versions)
-    } else {
-        nr_hits             = []
-        nr_full             = []
-    }
+    //     SUBWORKFLOW: EXTRACT RESULTS HITS FROM NT-BLAST
+
+    //     EXTRACT_NT_BLAST (
+    //         valid_length_fasta,
+    //         Channel.value(params.nt_database_path),
+    //         Channel.value(params.ncbi_accession_ids_folder),
+    //         Channel.value(params.ncbi_ranked_lineage_path)
+    //     )
+    //     ch_versions         = ch_versions.mix(EXTRACT_NT_BLAST.out.versions)
+    //     ch_nt_blast         = EXTRACT_NT_BLAST.out.ch_blast_hits.map{it[1]}
+    //     ch_blast_lineage    = EXTRACT_NT_BLAST.out.ch_top_lineages.map{it[1]}
+
+    // } else {
+    //     ch_nt_blast         = Channel.empty()
+    //     ch_blast_lineage    = Channel.empty()
+    // }
 
 
-    //
-    // SUBWORKFLOW: DIAMOND BLAST FOR INPUT ASSEMBLY
-    //
-    //qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore staxids sscinames sskingdoms sphylums salltitles
-    if ( (include_workflow_steps.contains('uniprot_diamond') || include_workflow_steps.contains('ALL')) &&
-            !exclude_workflow_steps.contains("uniprot_diamond") && !valid_length_fasta.ifEmpty(true)
-    ) {
-        UP_DIAMOND (
-            valid_length_fasta,
-            params.diamond_uniprot_database_path
-        )
-        un_full             = UP_DIAMOND.out.reformed.map{it[1]}
-        un_hits             = UP_DIAMOND.out.hits_file.map{it[1]}
-        ch_versions         = ch_versions.mix(UP_DIAMOND.out.versions)
-    } else {
-        un_hits             = []
-        un_full             = []
-    }
+    // //
+    // // SUBWORKFLOW: DIAMOND BLAST FOR INPUT ASSEMBLY
+    // //
+    // if ( (include_workflow_steps.contains('nr_diamond') || include_workflow_steps.contains('ALL')) &&
+    //         !exclude_workflow_steps.contains("nr_diamond") && !valid_length_fasta.ifEmpty(true)
+    // ) {
+    //     NR_DIAMOND (
+    //         valid_length_fasta,
+    //         params.diamond_nr_database_path
+    //     )
+    //     nr_full             = NR_DIAMOND.out.reformed.map{it[1]}
+    //     nr_hits             = NR_DIAMOND.out.hits_file.map{it[1]}
+    //     ch_versions         = ch_versions.mix(NR_DIAMOND.out.versions)
+    // } else {
+    //     nr_hits             = []
+    //     nr_full             = []
+    // }
 
 
-    if ( (include_workflow_steps.contains('create_btk_dataset') || include_workflow_steps.contains('ALL')) &&
-            !exclude_workflow_steps.contains("create_btk_dataset")
-    ) {
-        ch_dot_genome           = ESSENTIAL_JOBS.out.dot_genome.map{it[1]}
+    // //
+    // // SUBWORKFLOW: DIAMOND BLAST FOR INPUT ASSEMBLY
+    // //
+    // //qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore staxids sscinames sskingdoms sphylums salltitles
+    // if ( (include_workflow_steps.contains('uniprot_diamond') || include_workflow_steps.contains('ALL')) &&
+    //         !exclude_workflow_steps.contains("uniprot_diamond") && !valid_length_fasta.ifEmpty(true)
+    // ) {
+    //     UP_DIAMOND (
+    //         valid_length_fasta,
+    //         params.diamond_uniprot_database_path
+    //     )
+    //     un_full             = UP_DIAMOND.out.reformed.map{it[1]}
+    //     un_hits             = UP_DIAMOND.out.hits_file.map{it[1]}
+    //     ch_versions         = ch_versions.mix(UP_DIAMOND.out.versions)
+    // } else {
+    //     un_hits             = []
+    //     un_full             = []
+    // }
 
-        CREATE_BTK_DATASET (
-            ESSENTIAL_JOBS.out.reference_tuple_from_GG,
-            ch_dot_genome,
-            [], //ch_kmers
-            ch_tiara,
-            ch_nt_blast,
-            [], //ch_fcsgx,
-            ch_bam,
-            ch_coverage,
-            ch_kraken1,
-            ch_kraken2,
-            ch_kraken3,
-            nr_full,
-            un_full,
-            Channel.fromPath(params.ncbi_taxonomy_path).first()
-        )
-        ch_versions             = ch_versions.mix(CREATE_BTK_DATASET.out.versions)
-    }
+
+    // if ( (include_workflow_steps.contains('create_btk_dataset') || include_workflow_steps.contains('ALL')) &&
+    //         !exclude_workflow_steps.contains("create_btk_dataset")
+    // ) {
+    //     ch_dot_genome           = ESSENTIAL_JOBS.out.dot_genome.map{it[1]}
+
+    //     CREATE_BTK_DATASET (
+    //         ESSENTIAL_JOBS.out.reference_tuple_from_GG,
+    //         ch_dot_genome,
+    //         [], //ch_kmers
+    //         ch_tiara,
+    //         ch_nt_blast,
+    //         [], //ch_fcsgx,
+    //         ch_bam,
+    //         ch_coverage,
+    //         ch_kraken1,
+    //         ch_kraken2,
+    //         ch_kraken3,
+    //         nr_full,
+    //         un_full,
+    //         Channel.fromPath(params.ncbi_taxonomy_path).first()
+    //     )
+    //     ch_versions             = ch_versions.mix(CREATE_BTK_DATASET.out.versions)
+    // }
 
 
     //

--- a/workflows/ascc_organellar.nf
+++ b/workflows/ascc_organellar.nf
@@ -178,28 +178,28 @@ workflow ASCC_ORGANELLAR {
     }
 
 
-    // //
-    // // SUBWORKFLOW: CALCULATE AVERAGE READ COVERAGE
-    // //
-    // if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
-    //         !exclude_workflow_steps.contains("coverage")
-    // ) {
-    //     reads.view{"READS: $it"}
-    //     ESSENTIAL_JOBS.out.reference_tuple_from_GG.view{"REF: $it"}
-    //     println params.reads_type
+    //
+    // SUBWORKFLOW: CALCULATE AVERAGE READ COVERAGE
+    //
+    if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
+            !exclude_workflow_steps.contains("coverage")
+    ) {
+        reads.view{"READS: $it"}
+        ESSENTIAL_JOBS.out.reference_tuple_from_GG.view{"REF: $it"}
+        println params.reads_type
 
-    //     RUN_READ_COVERAGE (
-    //         ESSENTIAL_JOBS.out.reference_tuple_from_GG, // Again should this be the validated fasta?
-    //         reads,
-    //         params.reads_type,
-    //     )
-    //     ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
-    //     ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
-    //     ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
-    // } else {
-    //     ch_coverage         = []
-    //     ch_bam              = []
-    // }
+        RUN_READ_COVERAGE (
+            ESSENTIAL_JOBS.out.reference_tuple_from_GG, // Again should this be the validated fasta?
+            reads,
+            params.reads_type,
+        )
+        ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
+        ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
+        ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
+    } else {
+        ch_coverage         = []
+        ch_bam              = []
+    }
 
 
     //

--- a/workflows/ascc_organellar.nf
+++ b/workflows/ascc_organellar.nf
@@ -184,6 +184,10 @@ workflow ASCC_ORGANELLAR {
     if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
             !exclude_workflow_steps.contains("coverage")
     ) {
+        reads.view{"READS: $it"}
+        ESSENTIAL_JOBS.out.reference_tuple_from_GG.view{"REF: $it"}
+        println params.reads_type
+
         RUN_READ_COVERAGE (
             ESSENTIAL_JOBS.out.reference_tuple_from_GG, // Again should this be the validated fasta?
             reads,

--- a/workflows/ascc_organellar.nf
+++ b/workflows/ascc_organellar.nf
@@ -178,28 +178,28 @@ workflow ASCC_ORGANELLAR {
     }
 
 
-    //
-    // SUBWORKFLOW: CALCULATE AVERAGE READ COVERAGE
-    //
-    if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
-            !exclude_workflow_steps.contains("coverage")
-    ) {
-        reads.view{"READS: $it"}
-        ESSENTIAL_JOBS.out.reference_tuple_from_GG.view{"REF: $it"}
-        println params.reads_type
+    // //
+    // // SUBWORKFLOW: CALCULATE AVERAGE READ COVERAGE
+    // //
+    // if ( (include_workflow_steps.contains('coverage') || include_workflow_steps.contains('btk_busco') || include_workflow_steps.contains('ALL')) &&
+    //         !exclude_workflow_steps.contains("coverage")
+    // ) {
+    //     reads.view{"READS: $it"}
+    //     ESSENTIAL_JOBS.out.reference_tuple_from_GG.view{"REF: $it"}
+    //     println params.reads_type
 
-        RUN_READ_COVERAGE (
-            ESSENTIAL_JOBS.out.reference_tuple_from_GG, // Again should this be the validated fasta?
-            reads,
-            params.reads_type,
-        )
-        ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
-        ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
-        ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
-    } else {
-        ch_coverage         = []
-        ch_bam              = []
-    }
+    //     RUN_READ_COVERAGE (
+    //         ESSENTIAL_JOBS.out.reference_tuple_from_GG, // Again should this be the validated fasta?
+    //         reads,
+    //         params.reads_type,
+    //     )
+    //     ch_coverage         = RUN_READ_COVERAGE.out.tsv_ch.map{it[1]}
+    //     ch_bam              = RUN_READ_COVERAGE.out.bam_ch.map{it[1]}
+    //     ch_versions         = ch_versions.mix(RUN_READ_COVERAGE.out.versions)
+    // } else {
+    //     ch_coverage         = []
+    //     ch_bam              = []
+    // }
 
 
     //


### PR DESCRIPTION
Ensure GrabFiles only runs once per pipeline execution rather than twice (once per genomic and organellar run).

Fixed bug where FCS-GX started running only once per genomic and organellar run, even when it should be running once per supplied assembly.