### PR TITLE
Fix no default value for reads_layout

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
     taxid                               = null
     reads_path                          = null
     reads_type                          = "hifi"
-    reads_layout                        = null
+    reads_layout                        = "SINGLE"
     pacbio_barcode_file                 = "${projectDir}/assets/pacbio_adaptors.fa"
     pacbio_barcode_names                = null
     kmer_length                         = 7

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -52,8 +52,9 @@
                 "reads_layout": {
                     "type": "string",
                     "description": "Specify whether all reads are SINGLE or PAIRED end reads",
-                    "pattern": "^(SINGLE|PAIRED)$",
-                    "fa_icon": "fas fa-input-text"
+                    "enum": ["SINGLE", "PAIRED", "both", "off"],
+                    "fa_icon": "fas fa-input-text",
+                    "default": "SINGLE"
                 },
                 "pacbio_barcode_file": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -52,7 +52,7 @@
                 "reads_layout": {
                     "type": "string",
                     "description": "Specify whether all reads are SINGLE or PAIRED end reads",
-                    "enum": ["SINGLE", "PAIRED", "both", "off"],
+                    "enum": ["SINGLE", "PAIRED"],
                     "fa_icon": "fas fa-input-text",
                     "default": "SINGLE"
                 },


### PR DESCRIPTION
I think this should be fine as we already assume the read input type is "hifi"

- Adds default value for reads_layout
- Sets the expected input in the schema to an enum rather than a regex

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/ascc/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
