### PR TITLE
Dp24 production updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Release 5 of sanger-tol/ascc, correcting environments and updating module struct
   - channels cannot be compared
   - Removed channel.of(params....) to remedy this.
 - Added a missing process conditional.
+- KMER Analysis is now switched off in production.config
+  - This primarily effects only SANGER-TOLA production
+- Added new output from EXTRACT_CONTAMINANTS for parity with cobiontcheck (unreleased pre-nf_core ASCC pipeline).
+  - Output will be added to `organellar_contamination_recomendations`
 
 ## v0.3.0 - Red Lamp [02/05/2025]
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -237,12 +237,6 @@ process {
         ext.args        = { "--sensitive --max-target-seqs 3 --evalue 1e-25 --no-unlink --tmpdir ./" }
     }
 
-    withName: BLAST_BLASTN_MOD {
-    ext.args        = { '-outfmt "6 qseqid staxids bitscore std" -max_target_seqs 10 -max_hsps 1 -evalue 1e-25 -dust yes -lcase_masking' }
-        ext.prefix      = { "ascc-${meta2.id}" }
-        ext.dbprefix    = '*'
-    }
-
     withName: '.*:.*:.*:(PLASTID_ORGANELLAR_BLAST|MITO_ORGANELLAR_BLAST):BLAST_BLASTN' {
         ext.args        = { "-task megablast -word_size 28 -best_hit_overhang 0.1 -best_hit_score_edge 0.1 -dust yes -evalue 0.0001 -perc_identity 80 -soft_masking true -outfmt 7" }
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -153,15 +153,17 @@ process {
 
     withName: EXTRACT_CONTAMINANTS {
         publishDir      = [
-            path: { "${params.outdir}/${meta.id}/organelle_contamination_recommendations/extract_contaminants" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-        ],
-        [
-            path: { "${params.outdir}/${meta.id}/organelle_contamination_recommendations/" },
-            mode: params.publish_dir_mode,
-            pattern: "*.ALL*unfiltered_scaffold_coverage.bed",
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            [
+                path: { "${params.outdir}/${meta.id}/organelle_contamination_recommendations/extract_contaminants" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            ],
+            [
+                path: { "${params.outdir}/${meta.id}/organelle_contamination_recommendations/" },
+                mode: params.publish_dir_mode,
+                pattern: "*.ALL*unfiltered_scaffold_coverage.bed",
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            ]
         ]
     }
 
@@ -241,11 +243,11 @@ process {
         ext.args        = { "-task megablast -word_size 28 -best_hit_overhang 0.1 -best_hit_score_edge 0.1 -dust yes -evalue 0.0001 -perc_identity 80 -soft_masking true -outfmt 7" }
     }
 
-    withName: SAMTOOLS_DEPTH{
+    withName: SAMTOOLS_DEPTH {
         ext.args        = { "-aa" }
     }
 
-    withName: SAMTOOLS_SORT{
+    withName: SAMTOOLS_SORT {
         ext.prefix      = { "${meta.id}_sorted" }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -52,7 +52,7 @@ process {
         ]
     }
 
-    withName: "MITO_ORGANELLAR_BLAST" {
+    withName: MITO_ORGANELLAR_BLAST {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/mito_organellar_blast" },
             mode: params.publish_dir_mode,
@@ -148,6 +148,20 @@ process {
                 pattern: "*.{csv,fasta}",
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             ]
+        ]
+    }
+
+    withName: EXTRACT_CONTAMINANTS {
+        publishDir      = [
+            path: { "${params.outdir}/${meta.id}/organelle_contamination_recommendations/extract_contaminants" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ],
+        [
+            path: { "${params.outdir}/${meta.id}/organelle_contamination_recommendations/" },
+            mode: params.publish_dir_mode,
+            pattern: "*.ALL*unfiltered_scaffold_coverage.bed",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -78,7 +78,7 @@ process {
         ]
     }
 
-    withName:"TIARA_TIARA" {
+    withName: TIARA_TIARA {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/tiara_raw_output" },
             mode: params.publish_dir_mode,
@@ -86,7 +86,7 @@ process {
         ]
     }
 
-    withName: "SAMTOOLS_SORT" {
+    withName: SAMTOOLS_SORT {
         publishDir      = [
             path:   { "${params.outdir}/${meta.id}/sorted_mapped_bam/"},
             mode:   params.publish_dir_mode,
@@ -104,7 +104,7 @@ process {
         ]
     }
 
-    withName: "SAMTOOLS_DEPTH_AVERAGE_COVERAGE" {
+    withName: SAMTOOLS_DEPTH_AVERAGE_COVERAGE {
         publishDir = [
             path:   { "${params.outdir}/${meta.id}/average_coverage/"},
             mode:   params.publish_dir_mode,
@@ -227,7 +227,7 @@ process {
         ext.args        = { "-dbtype nucl" }
     }
 
-    withName: '.*:.*:.*:BLAST_BLASTN' {
+    withName: BLAST_BLASTN {
         ext.args        = { '-outfmt "6 qseqid staxids bitscore std" -max_target_seqs 10 -max_hsps 1 -evalue 1e-25 -dust yes -lcase_masking' }
         ext.prefix      = { "ascc-${meta2.id}" }
         ext.dbprefix    = '*'
@@ -237,7 +237,7 @@ process {
         ext.args        = { "--sensitive --max-target-seqs 3 --evalue 1e-25 --no-unlink --tmpdir ./" }
     }
 
-    withName: '.*:.*:.*:BLAST_BLASTN_MOD' {
+    withName: BLAST_BLASTN_MOD {
     ext.args        = { '-outfmt "6 qseqid staxids bitscore std" -max_target_seqs 10 -max_hsps 1 -evalue 1e-25 -dust yes -lcase_masking' }
         ext.prefix      = { "ascc-${meta2.id}" }
         ext.dbprefix    = '*'

--- a/conf/production.config
+++ b/conf/production.config
@@ -37,7 +37,7 @@ params {
     btk_yaml                            = "${baseDir}/assets/btk_draft.yaml"
 
     run_essentials                      = "both"
-    run_kmers                           = "genomic"
+    run_kmers                           = "off"
     run_tiara                           = "both"
     run_coverage                        = "both"
     run_nt_blast                        = "both"


### PR DESCRIPTION
- KMER Analysis is now switched off in production.config
  - This primarily affects only SANGER-TOLA production
- Added new output from EXTRACT_CONTAMINANTS for parity with cobiontcheck (unreleased pre-nf_core ASCC pipeline).
  - Output will be added to `/{outdir}/{assembly_id}/organellar_contamination_recomendations`
- Consistency with module naming and `"` in modules.config, unnecessary but it started to annoy...
- Removed reference to BLAST_BLASTN_MOD which no longer exists.