### PR TITLE
Updates to jinja branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - Red Notebook [##/##/2025]
+
+THIS IS STILL AN IN-DEVELOPMENT PROJECT SO THERE MAY BE BUGS.
+
+Release 10 of sanger-tol/ascc, addition of a report generator.
+
+### `Added`
+- Reporting for the pipeline output into a more human readable output (html).
+- Updated the naming of various outputs inorder to standardise them.
+
+### `Dependencies`
+
+| Module                        | Old Version                           | New Versions                          |
+| ----------------------------- | ------------------------------------- | ------------------------------------- |
+| AUTOFILTER_AND_CHECK_ASSEMBLY | abnormal_contamination_check.py:1.1.0 | abnormal_contamination_check.py:1.2.0 |
+
 ## [0.5.2] - Red Spider-Boat (H2) [06/10/2025]
 
 THIS IS STILL AN IN-DEVELOPMENT PROJECT SO THERE MAY BE BUGS.

--- a/assets/btk_config_files/btk_trace.config
+++ b/assets/btk_config_files/btk_trace.config
@@ -1,7 +1,7 @@
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/SummaryStats_${params.trace_report_suffix}.txt"
-    fields  = "task_id,hash,name,status,queue,host_name,attempt,exit,cpu_model,cpus,memory,%cpu,%mem,rss,peak_rss,vmem,peakvmem,start,complete,realtime,duration
+    file    = "${params.outdir}/pipeline_info/SummaryStats_BTK.txt"
+    fields  = "task_id,hash,name,status,queue,hostname,attempt,exit,cpu_model,cpus,memory,%cpu,%mem,rss,peak_rss,vmem,peak_vmem,start,complete,realtime,duration"
     sep     = "\t"
     override= true
 }

--- a/modules/local/ascc/merge_tables/main.nf
+++ b/modules/local/ascc/merge_tables/main.nf
@@ -44,7 +44,7 @@ process ASCC_MERGE_TABLES {
     def fcs_gx                      = fcs_gx                    ? "-fg ${fcs_gx}"                   : ""
 
     """
-    $baseDir/bin/ascc_merge_tables.py \\
+    ascc_merge_tables.py \\
         --gc_cov $gc_content \\
         --sample_name $meta.id \\
         $coverage \\

--- a/modules/local/autofilter/autofilter/main.nf
+++ b/modules/local/autofilter/autofilter/main.nf
@@ -26,7 +26,7 @@ process AUTOFILTER_AND_CHECK_ASSEMBLY {
     def prefix  = task.ext.prefix   ?: "${meta.id}"
     def args    = task.ext.args     ?: ""
     """
-    $baseDir/bin/autofilter.py \\
+    autofilter.py \\
         $reference \\
         --taxid $meta.taxid \\
         --tiara $tiara_txt \\
@@ -35,7 +35,7 @@ process AUTOFILTER_AND_CHECK_ASSEMBLY {
         --ncbi_rankedlineage_path $ncbi_rankedlineage \\
         ${args} \\
 
-    $baseDir/bin/abnormal_contamination_check.py \\
+    abnormal_contamination_check.py \\
         $reference \\
         ${prefix}_ABNORMAL_CHECK.csv \\
         --out_prefix ${prefix}

--- a/modules/local/blast/chunk_to_full/main.nf
+++ b/modules/local/blast/chunk_to_full/main.nf
@@ -18,7 +18,7 @@ process BLAST_CHUNK_TO_FULL {
     def args    = task.ext.args     ?: ''
     def prefix  = task.ext.prefix   ?: "${meta.id}"
     """
-    $baseDir/bin/blast_hit_chunk_coords_to_full_coords.py ${chunked} ${args} > ${meta.id}_full_coords.tsv
+    blast_hit_chunk_coords_to_full_coords.py ${chunked} ${args} > ${meta.id}_full_coords.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/blast/get_top_hits/main.nf
+++ b/modules/local/blast/get_top_hits/main.nf
@@ -17,7 +17,7 @@ process BLAST_GET_TOP_HITS {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/blast_get_top_hits.py ${outfmt6} > ${prefix}_tophits.tsv
+    blast_get_top_hits.py ${outfmt6} > ${prefix}_tophits.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/blobtoolkit/create_dataset/main.nf
+++ b/modules/local/blobtoolkit/create_dataset/main.nf
@@ -50,7 +50,7 @@ process CREATE_BTK_DATASET {
     """
     mkdir -p btk_datasets_CBD/
 
-    $baseDir/bin/create_btk_dataset.py \\
+    create_btk_dataset.py \\
         -o btk_datasets_CBD \\
         -f ${reference} \\
         -d ./1/ \\

--- a/modules/local/blobtoolkit/merge_dataset/main.nf
+++ b/modules/local/blobtoolkit/merge_dataset/main.nf
@@ -26,7 +26,7 @@ process MERGE_BTK_DATASETS {
     """
     mkdir -p merged_datasets/
 
-    $baseDir/bin/merge_btk_datasets.py \\
+    merge_btk_datasets.py \\
         -m $create_btk_datasets \\
         -o ./merged_btk_datasets \\
         -b $btk_busco_datasets \\

--- a/modules/local/check/barcode/main.nf
+++ b/modules/local/check/barcode/main.nf
@@ -21,7 +21,7 @@ process CHECK_BARCODE {
     def args        = task.ext.args     ?: ''
     """
     OUTPUT=\$(\\
-        $baseDir/bin/pacbio_barcode_check.py \\
+        pacbio_barcode_check.py \\
             -b ${barcodes} \\
             -p in/ \\
             -m ${multiplex_csv})

--- a/modules/local/check/nt_blast_taxonomy/main.nf
+++ b/modules/local/check/nt_blast_taxonomy/main.nf
@@ -16,7 +16,7 @@ process CHECK_NT_BLAST_TAXONOMY {
 
     script:
     """
-    $baseDir/bin/check_nt_blast_taxonomy.py --db_path ${nt_blast_db_path}
+    check_nt_blast_taxonomy.py --db_path ${nt_blast_db_path}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/extract/contaminants/main.nf
+++ b/modules/local/extract/contaminants/main.nf
@@ -19,7 +19,7 @@ process EXTRACT_CONTAMINANTS {
     def args    = task.ext.args     ?: ''
     def prefix  = task.ext.prefix   ?: "${meta.id}"
     """
-    $baseDir/bin/extract_contaminants_by_type.py \\
+    extract_contaminants_by_type.py \\
         ${blast_data} \\
         --assembly_file ${fasta} \\
         --out_prefix ${prefix}

--- a/modules/local/fcsgx/parse_results/main.nf
+++ b/modules/local/fcsgx/parse_results/main.nf
@@ -19,7 +19,7 @@ process PARSE_FCSGX_RESULT {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/parse_fcsgx_result.py ${fcs_gx_reports_folder} ${ncbi_rankedlineage_path} > ${prefix}_parsed_fcsgx.csv
+    parse_fcsgx_result.py ${fcs_gx_reports_folder} ${ncbi_rankedlineage_path} > ${prefix}_parsed_fcsgx.csv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/filter/barcode/main.nf
+++ b/modules/local/filter/barcode/main.nf
@@ -18,7 +18,7 @@ process FILTER_BARCODE {
     def args    = task.ext.args     ?: ''
     def prefix  = task.ext.prefix   ?: "${meta.id}"
     """
-    $baseDir/bin/filter_barcode_blast_results.py \\
+    filter_barcode_blast_results.py \\
         --input ${fasta} \\
         --barcode ${barcodes} \\
         --blast ${blast_data} \\

--- a/modules/local/filter/fasta/main.nf
+++ b/modules/local/filter/fasta/main.nf
@@ -29,13 +29,13 @@ process FILTER_FASTA {
     // Conditionally add the max header length argument
     def max_header_arg = check_fcs_header_len ? "--max_header_len 50" : ""
     """
-    $baseDir/bin/sanitise_input_fasta_file.py \\
+    sanitise_input_fasta_file.py \\
         ${input_fasta} \\
         ${max_header_arg} \\
         --log_file fasta_sanitation.json \\
         --max_detailed_changes 0 > ${prefix}_shortened.fasta
 
-    $baseDir/bin/filter_fasta_by_length.py \\
+    filter_fasta_by_length.py \\
         ${args} \\
         ${prefix}_shortened.fasta \\
         ${max_length} \\

--- a/modules/local/filter/vecscreen_results/main.nf
+++ b/modules/local/filter/vecscreen_results/main.nf
@@ -21,7 +21,7 @@ process FILTER_VECSCREEN_RESULTS {
     def prefix      = task.ext.prefix ?: "${meta.id}"
     def args        = task.ext.args ?: ''
     """
-    $baseDir/bin/VSlistTo1HitPerLine.py ${args} ${vecscreen_outfile} > ${prefix}_vecscreen.grepped.out
+    VSlistTo1HitPerLine.py ${args} ${vecscreen_outfile} > ${prefix}_vecscreen.grepped.out
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/gc/content/main.nf
+++ b/modules/local/gc/content/main.nf
@@ -17,7 +17,7 @@ process GC_CONTENT {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/gc_content.py ${fasta} > ${prefix}-GC_CONTENT.txt
+    gc_content.py ${fasta} > ${prefix}-GC_CONTENT.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/generate_html_report/main.nf
+++ b/modules/local/generate_html_report/main.nf
@@ -11,40 +11,41 @@ process GENERATE_HTML_REPORT {
 
     input:
     tuple val(meta),
-        path(barcode_results, stageAs: "barcodes/*"),
-        path(fcs_adaptor_euk, stageAs: "fcs/*"),
-        path(fcs_adaptor_prok, stageAs: "fcs/*"),
-        path(trim_ns_results, stageAs: "trailingns/*"),
-        path(vecscreen_results, stageAs: "vecscreen/*"),
-        path(autofilter_results, stageAs: "autofilter/*"),
-        path(merged_table, stageAs: "merged/*"),
-        path(phylum_counts, stageAs: "coverage/*"),       // Add phylum coverage data input
-        path(kmers_results, stageAs: "kmers/**"),
+        path(barcode_results,               stageAs: "barcodes/*"),
+        path(fcs_adaptor_euk,               stageAs: "fcs/*"),
+        path(fcs_adaptor_prok,              stageAs: "fcs/*"),
+        path(trim_ns_results,               stageAs: "trailingns/*"),
+        path(vecscreen_results,             stageAs: "vecscreen/*"),
+        path(autofilter_results,            stageAs: "autofilter/*"),
+        path(merged_table,                  stageAs: "merged/*"),
+        path(phylum_counts,                 stageAs: "coverage/*"),
+        path(kmers_results,                 stageAs: "kmers/**"),
         path(reference_fasta),
-        path(fasta_sanitation_log, stageAs: "fasta_sanitation/*"),
-        path(fasta_length_filtering_log, stageAs: "fasta_length_filtering/*"),
-        path(fcs_gx_report_txt, stageAs: "fcsgx/*"),      // Add FCS-GX report txt input
-        path(fcs_gx_taxonomy_rpt, stageAs: "fcsgx/*"),    // Add FCS-GX taxonomy rpt input
-        path(btk_output_dir, stageAs: "btk/*")            // Add BTK output dir input
-    path(jinja_templates_list, stageAs: "templates/*") // Updated to accept a list and stage them
+        path(fasta_sanitation_log,          stageAs: "fasta_sanitation/*"),
+        path(fasta_length_filtering_log,    stageAs: "fasta_length_filtering/*"),
+        path(fcs_gx_report_txt,             stageAs: "fcsgx/*"),
+        path(fcs_gx_taxonomy_rpt,           stageAs: "fcsgx/*"),
+        path(btk_output_dir,                stageAs: "btk/*")
+    path(jinja_templates_list,              stageAs: "templates/*")
     path(samplesheet)
     path(params_file)
     val(params_json)
-    path(css_files_list, stageAs: "css/*") // CSS files to include in the report
+    path(css_files_list, stageAs: "css/*")
 
     output:
     tuple val(meta), path("report/site/*"), emit: report
-    path "versions.yml", emit: versions
+    path "versions.yml",                    emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    // Use the reference FASTA file passed as a parameter
-    def reference_file = reference_fasta ? "--reference ${reference_fasta}" : ""
+    def prefix          = task.ext.prefix   ?: "${meta.id}"
     // Convert params_json to a properly escaped string for command line
-    def params_json_arg = params_json ? "--params_json '${params_json.replaceAll("'", "\\'")}'" : ""
+    def params_json_arg = params_json       ? "--params_json '${params_json.replaceAll("'", "\\'")}'" : ""
+    def params_file     = params_file       ? "--params_file ${params_file}" : ""
+    def btk_included    = "${params.run_create_btk_dataset == 'both' || (params.run_create_btk_dataset == 'genomic' && params.genomic_only) || (params.run_create_btk_dataset == 'organellar' && !params.genomic_only)}"
+    def btk_outdir      = "${params.outdir}/${meta.id}"
     """
     mkdir -p report/site/templates
     mkdir -p report/site/css
@@ -59,7 +60,7 @@ process GENERATE_HTML_REPORT {
     ls -la kmers/
 
     # Run the report generation script directly from bin directory
-    python $baseDir/bin/generate_html_report.py \\
+    generate_html_report.py \\
         --output_dir report \\
         --template_dir report/site/templates \\
         --barcode_dir barcodes \\
@@ -70,49 +71,40 @@ process GENERATE_HTML_REPORT {
         --merged_dir merged \\
         --coverage_dir coverage \\
         --kmers_dir kmers \\
-        $reference_file \\
+        --reference ${reference_fasta} \\
         --fasta_sanitation_log fasta_sanitation/fasta_sanitation.json \\
         --fasta_length_filtering_log fasta_length_filtering/fasta_length_filtering.json \\
-        --samplesheet $samplesheet \\
-        ${params_file ? "--params_file $params_file" : ""} \\
-        $params_json_arg \\
+        --samplesheet ${samplesheet} \\
+        ${params_file} \\
+        ${params_json_arg} \\
         --fcs_gx_report_txt fcsgx/*.fcs_gx_report.txt \\
         --fcs_gx_taxonomy_rpt fcsgx/*.taxonomy.rpt \\
-        --btk_published_path "${params.outdir}/${meta.id}/create_btk_dataset/btk_datasets_CBD" \\
-        --btk_included "${params.run_create_btk_dataset == 'both' || (params.run_create_btk_dataset == 'genomic' && params.genomic_only) || (params.run_create_btk_dataset == 'organellar' && !params.genomic_only)}" \\
+        --btk_published_path "${btk_outdir}/create_btk_dataset/btk_datasets_CBD" \\
+        --btk_included "${btk_included}" \\
         --launch_dir "${workflow.launchDir}" \\
         --pipeline_version ${workflow.manifest.version} \\
-        --output_prefix $prefix
+        --output_prefix ${prefix}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')
         jinja2: \$(python -c 'import jinja2; print(jinja2.__version__)')
         pandas: \$(python -c 'import pandas; print(pandas.__version__)')
-        generate_html_report: \$(python $baseDir/bin/generate_html_report.py --version 2>&1 | sed 's/.*version //g')
+        generate_html_report: \$(python generate_html_report.py --version 2>&1 | sed 's/.*version //g')
     END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    mkdir -p report/site/templates
-    mkdir -p report/site/css
-    mkdir -p report/site/kmers
-    cp -r kmers/* report/site/kmers
-    cp css/*.css report/site/css/
     touch report/site/${prefix}.html
-
-
-    # Run the report generation script (stub mode)
-    echo "Would run python $baseDir/bin/generate_html_report.py --pipeline_version ${workflow.manifest.version} --fcs_gx_report_txt fcsgx/*.fcs_gx_report.txt --fcs_gx_taxonomy_rpt fcsgx/*.taxonomy.rpt with samplesheet $samplesheet ${params_file ? "and params file $params_file" : ""} and FASTA sanitation logs"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')
         jinja2: \$(python -c 'import jinja2; print(jinja2.__version__)')
         pandas: \$(python -c 'import pandas; print(pandas.__version__)')
-        generate_html_report: \$(python $baseDir/bin/generate_html_report.py --version 2>&1 | sed 's/.*version //g')
+        generate_html_report: \$(python generate_html_report.py --version 2>&1 | sed 's/.*version //g')
     END_VERSIONS
     """
 }

--- a/modules/local/get/kmer_counts/main.nf
+++ b/modules/local/get/kmer_counts/main.nf
@@ -22,7 +22,7 @@ process GET_KMER_COUNTS {
     def KMERCOUNTER_VERSION = "0.1.2"
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/kmer-counter -f $input_fasta -k $kmer_size -o ${prefix}_kmer_counts.npy
+    kmer-counter -f $input_fasta -k $kmer_size -o ${prefix}_kmer_counts.npy
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/get/lineage_for_kraken/main.nf
+++ b/modules/local/get/lineage_for_kraken/main.nf
@@ -23,7 +23,7 @@ process GET_LINEAGE_FOR_KRAKEN {
     def GENERAL_FUNCTIONS   = "1.0.0"
     def prefix              = args.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/get_lineage_for_kraken_results.py \\
+    get_lineage_for_kraken_results.py \\
         $kraken_file \\
         $ncbi_rankedlineage_path \\
         nt \\

--- a/modules/local/get/lineage_for_top/main.nf
+++ b/modules/local/get/lineage_for_top/main.nf
@@ -17,7 +17,7 @@ process GET_LINEAGE_FOR_TOP {
 
     script:
     """
-    $baseDir/bin/get_lineage_for_top.py --blast_tsv ${tophits} --taxdump ${ncbi_lineage_path} --output_csv ./${meta.id}_BLAST_results_with_lineage.csv --column_name_prefix nt_
+    get_lineage_for_top.py --blast_tsv ${tophits} --taxdump ${ncbi_lineage_path} --output_csv ./${meta.id}_BLAST_results_with_lineage.csv --column_name_prefix nt_
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/kmer_count/dim_reduction/main.nf
+++ b/modules/local/kmer_count/dim_reduction/main.nf
@@ -31,7 +31,7 @@ process KMER_COUNT_DIM_REDUCTION {
     mkdir -p $dir_name
 
     # Run the dimensionality reduction and save the output in the directory
-    $baseDir/bin/kmer_count_dim_reduction.py \\
+    kmer_count_dim_reduction.py \\
         $kmer_counts_file \\
         $dir_name \\
         --selected_methods $dimensionality_reduction_method \\

--- a/modules/local/kmer_count/dim_reduction_combine_csv/main.nf
+++ b/modules/local/kmer_count/dim_reduction_combine_csv/main.nf
@@ -20,7 +20,7 @@ process KMER_COUNT_DIM_REDUCTION_COMBINE_CSV {
     script:
     def prefix = args.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/kmer_count_dim_reduction_combine_csv.py \\
+    kmer_count_dim_reduction_combine_csv.py \\
         -o ${prefix}_kmers_dim_reduction_embeddings_combined.csv \\
         -i $input_files
 

--- a/modules/local/organelle/contamination_recommendations/main.nf
+++ b/modules/local/organelle/contamination_recommendations/main.nf
@@ -18,7 +18,7 @@ process ORGANELLE_CONTAMINATION_RECOMMENDATIONS {
     def args    = task.ext.args ?: ''
     def prefix  = task.ext.prefix ?: "${meta.id}-${meta.organelle}"
     """
-    $baseDir/bin/organelle_contamination_recommendation.py \\
+    organelle_contamination_recommendation.py \\
         --input "${files}" \\
         --output ${prefix}.contamination_recommendation
 

--- a/modules/local/reformat/diamond_outfmt6/main.nf
+++ b/modules/local/reformat/diamond_outfmt6/main.nf
@@ -17,7 +17,7 @@ process REFORMAT_DIAMOND_OUTFMT6 {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/reformat_diamond_outfmt6.py ${diamond_blast} > ${prefix}_diamond_outfmt6.tsv
+    reformat_diamond_outfmt6.py ${diamond_blast} > ${prefix}_diamond_outfmt6.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/reformat/full_outfmt6/main.nf
+++ b/modules/local/reformat/full_outfmt6/main.nf
@@ -17,7 +17,7 @@ process REFORMAT_FULL_OUTFMT6 {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/reformat_blast_outfmt6.py ${full_blast} > ${prefix}_outfmt6.tsv
+    reformat_blast_outfmt6.py ${full_blast} > ${prefix}_outfmt6.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/reformat/npy_2_csv/main.nf
+++ b/modules/local/reformat/npy_2_csv/main.nf
@@ -21,12 +21,12 @@ process REFORMAT_NPY_2_CSV {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/npy_2_csv.py -f $fasta -k $kmer_size -n $npy -o ${prefix}_KMER_COUNTS.csv
+    npy_2_csv.py -f $fasta -k $kmer_size -n $npy -o ${prefix}_KMER_COUNTS.csv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')
-        npy_2_csv.py: \$($baseDir/bin/npy_2_csv.py --version | cut -d' ' -f2)
+        npy_2_csv.py: \$(npy_2_csv.py --version | cut -d' ' -f2)
     END_VERSIONS
     """
 
@@ -38,7 +38,7 @@ process REFORMAT_NPY_2_CSV {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')
-        npy_2_csv.py: \$($baseDir/bin/npy_2_csv.py --version | cut -d' ' -f2)
+        npy_2_csv.py: \$(npy_2_csv.py --version | cut -d' ' -f2)
     END_VERSIONS
     """
 }

--- a/modules/local/reformat/to_hits_file/main.nf
+++ b/modules/local/reformat/to_hits_file/main.nf
@@ -17,7 +17,7 @@ process REFORMAT_TO_HITS_FILE {
     script:
     def args    =   task.ext.args   ?: ""
     """
-    $baseDir/bin/convert_to_hits.py $blast_full $args
+    convert_to_hits.py $blast_full $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/samtools/depth_average_coverage/main.nf
+++ b/modules/local/samtools/depth_average_coverage/main.nf
@@ -18,7 +18,7 @@ process SAMTOOLS_DEPTH_AVERAGE_COVERAGE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/samtools_depth_average_coverage.py $depth > ${prefix}_average_coverage.txt
+    samtools_depth_average_coverage.py $depth > ${prefix}_average_coverage.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/trailingns/trailingns/main.nf
+++ b/modules/local/trailingns/trailingns/main.nf
@@ -21,7 +21,7 @@ process TRAILINGNS {
     def prefix  = args.ext.prefix   ?: "${meta.id}"
     def args    = args.ext.args     ?: ""
     """
-    $baseDir/bin/trim_Ns.py $fasta_input_file ${prefix}_trim_Ns ${args}
+    trim_Ns.py $fasta_input_file ${prefix}_trim_Ns ${args}
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')

--- a/modules/local/validate/taxid/main.nf
+++ b/modules/local/validate/taxid/main.nf
@@ -16,7 +16,7 @@ process VALIDATE_TAXID {
 
     script:
     """
-    $baseDir/bin/find_taxid_in_taxdump.py \\
+    find_taxid_in_taxdump.py \\
         $taxid \\
         ${ncbi_taxonomy_path}/nodes.dmp
 

--- a/modules/local/vecscreen/chunk_assembly/main.nf
+++ b/modules/local/vecscreen/chunk_assembly/main.nf
@@ -21,7 +21,7 @@ process CHUNK_ASSEMBLY_FOR_VECSCREEN {
     def prefix  = args.ext.prefix   ?: "${meta.id}"
     def args    = args.ext.args     ?: ""
     """
-    $baseDir/bin/chunk_assembly_for_vecscreen.py $fasta_input_file ${prefix}_chunked_assembly.fa ${args}
+    chunk_assembly_for_vecscreen.py $fasta_input_file ${prefix}_chunked_assembly.fa ${args}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/vecscreen/summarise/main.nf
+++ b/modules/local/vecscreen/summarise/main.nf
@@ -20,7 +20,7 @@ process SUMMARISE_VECSCREEN_OUTPUT {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    $baseDir/bin/summarise_vecscreen_output.py ${vecscreen_filtered_outfile} > ${prefix}.vecscreen_contamination
+    summarise_vecscreen_output.py ${vecscreen_filtered_outfile} > ${prefix}.vecscreen_contamination
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Running list of changes to Eeriks V4 template branch. Still ongoing but I needed to see where this is at compared to the other branch.

- Some of these are fixes for my things that i've noticed
  - btk.config
  - CHANGELOG
  - some map changes to make them *more* verbose
  - some note changes
  - made some channel naming more consistent (ESSENTIAL JOB outputs are prepended with ej)
  - Changed some log.info/warn assignments. Something following the proper route doesn't need a warning.
  - Removed the multiple dot file maps

- `$baseDir/bin/` is not needed, nextflow links bin to the container/module when the process starts. So it is just added verboseness.
- Removed the `id: "empty"` in already empty channels, it's unnecessary as the empty value isn't used at all. Replaced with: `( [[],[]] )`
- `generate_html_report/main.nf`
  - Removed the comments, used inconsistently and the channel is fairly self explanatory.
  - Removed tertiary comparisons out of the script and into the scripts def block.
  - Removed the `python generate_html_report` call as that crashes the module.
  - reference doesn't need to be a tertiary input - it's a mandatory input and always available.
  - Harshil alignment
- Added "empty" channels to subworkflow blocks rather than what is effectively duplicate code in the GENERATE_HTML_REPORT block
- Removed the `Channel :? Channel(empty)` assignments, as it duplicates the logic already in place.

- Organellar subworkflow includes all changes as above
- Replaced the manually created `org_processChannels` block with the block used in the GENOMIC workflow, it does the same thing but in a much more dynamic fashion. Also removes `this.binding.hasVariable('ch_kraken3')` which isn't something i've seen used before and would rather have consistent with the Genomic subworkflow and other channel checking going on.