### PR TITLE
Update trace file path in btk_trace.config

### DIFF
--- a/assets/btk_config_files/btk_trace.config
+++ b/assets/btk_config_files/btk_trace.config
@@ -1,6 +1,6 @@
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/SummaryStats_${params.trace_report_suffix}.txt"
+    file    = "${params.outdir}/pipeline_info/SummaryStats_BTK.txt"
     fields  = "task_id,hash,name,status,queue,hostname,attempt,exit,cpu_model,cpus,memory,%cpu,%mem,rss,peak_rss,vmem,peakvmem,start,complete,realtime,duration"
     sep     = "\t"
     override= true


### PR DESCRIPTION
Another awkward fix

Fixes the fact that params.trace_report_suffix doesn't exist at this point.