### PR TITLE
Fix bug with paths breaking a channel definition if there's more than 1

### DIFF
--- a/workflows/ascc_genomic.nf
+++ b/workflows/ascc_genomic.nf
@@ -685,7 +685,9 @@ workflow ASCC_GENOMIC {
     //          EXEC MODULE PRODUCES NO VERSIONS
     //
     combined_ch
-        .combine( reads_path.collect() )
+        .combine( reads_path.collect()
+            .map { paths -> [paths] }
+        )
         .map { meta, ref, alarm, path_list ->
             [[id:meta.id], path_list]
         }


### PR DESCRIPTION
@prototaxites found a bug where a list of paths for reads wern't being pulled into a list like I expected.

.collect flattens any list of files

We now map the contents of the reads_path.collect into a list before further processing.