### PR TITLE
Trash workdir

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -85,7 +85,7 @@ process {
         }
         time   = {
             def refSize = reference.size()
-            1.h  * ( refSize < 1e9 ? 10 : refSize < 10e9 ? 30 : 48)
+            1.h  * ( refSize < 1e9 ? 10 : refSize < 10e9 ? 30 : 48 ) * task.attempt
         }
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -154,7 +154,7 @@ process {
         ]
     }
 
-    withName: ASCC_MERGE_TABLES {
+    withName: "ASCC_MERGE_TABLES|DECONTAMINATE_GENERATE_BED|DECONTAMINATE_GENERATE_BED" {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/ascc_main_output" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -154,7 +154,7 @@ process {
         ]
     }
 
-    withName: "ASCC_MERGE_TABLES|DECONTAMINATE_GENERATE_BED|DECONTAMINATE_GENERATE_BED" {
+    withName: "ASCC_MERGE_TABLES|DECONTAMINATE_GENERATE_BED|DECONTAMINATE_CLIP_REGIONS_FASTA" {
         publishDir      = [
             path: { "${params.outdir}/${meta.id}/ascc_main_output" },
             mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -27,6 +27,8 @@ params {
     max_memory = '10.GB'
     max_time   = '6.h'
 
+    deepclean = true
+
     // Input params
     outdir                              = "ASCC-TEST"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,6 +70,8 @@ params {
     run_merge_datasets                  = "genomic"
     run_decontaminate_fasta             = "both"
 
+    deepclean                           = false
+
     // Boilerplate options
     outdir                              = null
     publish_dir_mode                    = 'copy'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -48,12 +51,20 @@
                     "description": "Type of read (hifi)",
                     "fa_icon": "fas fa-input-text",
                     "default": "hifi",
-                    "enum": ["hifi", "clr", "ont", "illumina"]
+                    "enum": [
+                        "hifi",
+                        "clr",
+                        "ont",
+                        "illumina"
+                    ]
                 },
                 "reads_layout": {
                     "type": "string",
                     "description": "Specify whether all reads are SINGLE or PAIRED end reads",
-                    "enum": ["SINGLE", "PAIRED"],
+                    "enum": [
+                        "SINGLE",
+                        "PAIRED"
+                    ],
                     "fa_icon": "fas fa-input-text",
                     "default": "SINGLE"
                 },
@@ -188,122 +199,214 @@
                 "run_essentials": {
                     "type": "string",
                     "description": "Run essential jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_kmers": {
                     "type": "string",
                     "description": "Run kmer jobs on assemblies",
-                    "enum": ["genomic", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "both",
+                        "off"
+                    ],
                     "default": "genomic"
                 },
                 "run_tiara": {
                     "type": "string",
                     "description": "Run tiara jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_coverage": {
                     "type": "string",
                     "description": "Run coverage jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_nt_blast": {
                     "type": "string",
                     "description": "Run nt_blast jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_html_report": {
                     "type": "string",
                     "description": "Run HTML report generation on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "off"
                 },
                 "run_nr_diamond": {
                     "type": "string",
                     "description": "Run nr_diamond jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_uniprot_diamond": {
                     "type": "string",
                     "description": "Run uniprot_diamond jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_kraken": {
                     "type": "string",
                     "description": "Run kraken jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_fcsgx": {
                     "type": "string",
                     "description": "Run fcsgx jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_fcs_adaptor": {
                     "type": "string",
                     "description": "Run fcs_adaptor jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_vecscreen": {
                     "type": "string",
                     "description": "Run vecscreen jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_btk_busco": {
                     "type": "string",
                     "description": "Run btk_busco jobs on assemblies",
-                    "enum": ["genomic", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "both",
+                        "off"
+                    ],
                     "default": "genomic"
                 },
                 "run_pacbio_barcodes": {
                     "type": "string",
                     "description": "Run pacbio_barcodes jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_organellar_blast": {
                     "type": "string",
                     "description": "Run organellar_blast jobs on assemblies",
-                    "enum": ["genomic", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "both",
+                        "off"
+                    ],
                     "default": "genomic"
                 },
                 "run_autofilter_assembly": {
                     "type": "string",
                     "description": "Run autofilter_assembly jobs on assemblies",
-                    "enum": ["genomic", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "both",
+                        "off"
+                    ],
                     "default": "genomic"
                 },
                 "run_create_btk_dataset": {
                     "type": "string",
                     "description": "Run create_btk_dataset jobs on assemblies",
-                    "enum": ["genomic", "organellar", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "organellar",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "run_merge_datasets": {
                     "type": "string",
                     "description": "Run merge_datasets jobs on assemblies",
-                    "enum": ["genomic", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "both",
+                        "off"
+                    ],
                     "default": "genomic"
                 },
                 "run_decontaminate_fasta": {
                     "type": "string",
                     "description": "Run decontaminate fasta, fasta will automatically be decontaminated if btk doesn't run",
-                    "enum": ["genomic", "both", "off"],
+                    "enum": [
+                        "genomic",
+                        "both",
+                        "off"
+                    ],
                     "default": "both"
                 },
                 "btk_busco_run_mode": {
                     "type": "string",
                     "description": "Should btk be run as mandatory or conditional on levels of contamination.",
                     "fa_icon": "fas fa-file-lines",
-                    "enum": ["mandatory", "conditional"],
+                    "enum": [
+                        "mandatory",
+                        "conditional"
+                    ],
                     "default": "conditional"
                 },
                 "genomic_only": {
@@ -326,6 +429,12 @@
                     "mimetype": "text/csv",
                     "description": "Override the internal FCS and provide your own. READ THE DOCS TO MAKE SURE IT IS GENERATED CORRECTLY.",
                     "fa_icon": "fas fa-file-lines"
+                },
+                "deepclean": {
+                    "type": "boolean",
+                    "description": "Delete the entire workDir",
+                    "fa_icon": "fas fa-file-lines",
+                    "default": false
                 }
             }
         },
@@ -396,7 +505,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -51,20 +48,12 @@
                     "description": "Type of read (hifi)",
                     "fa_icon": "fas fa-input-text",
                     "default": "hifi",
-                    "enum": [
-                        "hifi",
-                        "clr",
-                        "ont",
-                        "illumina"
-                    ]
+                    "enum": ["hifi", "clr", "ont", "illumina"]
                 },
                 "reads_layout": {
                     "type": "string",
                     "description": "Specify whether all reads are SINGLE or PAIRED end reads",
-                    "enum": [
-                        "SINGLE",
-                        "PAIRED"
-                    ],
+                    "enum": ["SINGLE", "PAIRED"],
                     "fa_icon": "fas fa-input-text",
                     "default": "SINGLE"
                 },
@@ -199,214 +188,122 @@
                 "run_essentials": {
                     "type": "string",
                     "description": "Run essential jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_kmers": {
                     "type": "string",
                     "description": "Run kmer jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "both", "off"],
                     "default": "genomic"
                 },
                 "run_tiara": {
                     "type": "string",
                     "description": "Run tiara jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_coverage": {
                     "type": "string",
                     "description": "Run coverage jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_nt_blast": {
                     "type": "string",
                     "description": "Run nt_blast jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_html_report": {
                     "type": "string",
                     "description": "Run HTML report generation on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "off"
                 },
                 "run_nr_diamond": {
                     "type": "string",
                     "description": "Run nr_diamond jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_uniprot_diamond": {
                     "type": "string",
                     "description": "Run uniprot_diamond jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_kraken": {
                     "type": "string",
                     "description": "Run kraken jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_fcsgx": {
                     "type": "string",
                     "description": "Run fcsgx jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_fcs_adaptor": {
                     "type": "string",
                     "description": "Run fcs_adaptor jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_vecscreen": {
                     "type": "string",
                     "description": "Run vecscreen jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_btk_busco": {
                     "type": "string",
                     "description": "Run btk_busco jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "both", "off"],
                     "default": "genomic"
                 },
                 "run_pacbio_barcodes": {
                     "type": "string",
                     "description": "Run pacbio_barcodes jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_organellar_blast": {
                     "type": "string",
                     "description": "Run organellar_blast jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "both", "off"],
                     "default": "genomic"
                 },
                 "run_autofilter_assembly": {
                     "type": "string",
                     "description": "Run autofilter_assembly jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "both", "off"],
                     "default": "genomic"
                 },
                 "run_create_btk_dataset": {
                     "type": "string",
                     "description": "Run create_btk_dataset jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "organellar",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "organellar", "both", "off"],
                     "default": "both"
                 },
                 "run_merge_datasets": {
                     "type": "string",
                     "description": "Run merge_datasets jobs on assemblies",
-                    "enum": [
-                        "genomic",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "both", "off"],
                     "default": "genomic"
                 },
                 "run_decontaminate_fasta": {
                     "type": "string",
                     "description": "Run decontaminate fasta, fasta will automatically be decontaminated if btk doesn't run",
-                    "enum": [
-                        "genomic",
-                        "both",
-                        "off"
-                    ],
+                    "enum": ["genomic", "both", "off"],
                     "default": "both"
                 },
                 "btk_busco_run_mode": {
                     "type": "string",
                     "description": "Should btk be run as mandatory or conditional on levels of contamination.",
                     "fa_icon": "fas fa-file-lines",
-                    "enum": [
-                        "mandatory",
-                        "conditional"
-                    ],
+                    "enum": ["mandatory", "conditional"],
                     "default": "conditional"
                 },
                 "genomic_only": {
@@ -505,14 +402,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/ascc.nf
+++ b/workflows/ascc.nf
@@ -171,9 +171,7 @@ workflow.onComplete {
                 log.warn "[ASCC WARN]: Could not clean up work directory: ${e.message}"
             }
 
-        } else if (!workflow.success) {
-            log.info "[ASCC INFO]: Pipeline failed - work directory preserved for debugging: ${workflow.workDir}"
-        } else {
+        } else if (!params.deepclean) {
             log.info "[ASCC INFO]: No Cleanup needed for: ${workflow.workDir}"
         }
     }

--- a/workflows/ascc.nf
+++ b/workflows/ascc.nf
@@ -171,7 +171,7 @@ workflow.onComplete {
                 log.warn "[ASCC WARN]: Could not clean up work directory: ${e.message}"
             }
 
-        } else if (!params.deepclean) {
+        } else {
             log.info "[ASCC INFO]: No Cleanup needed for: ${workflow.workDir}"
         }
     }

--- a/workflows/ascc.nf
+++ b/workflows/ascc.nf
@@ -145,7 +145,7 @@ workflow.onComplete {
             log.warn "Failed to create completion file: ${e.message}"
         }
 
-        if ( params.deepclean && worflow.success ) {
+        if ( params.deepclean ) {
 
             try {
                 //simple command to get size of work directory

--- a/workflows/ascc.nf
+++ b/workflows/ascc.nf
@@ -140,9 +140,9 @@ workflow.onComplete {
                 Launch directory: ${workflow.launchDir}
                 Command line: ${workflow.commandLine}
             """.stripIndent()
-            log.info "Completion file created: ${completionFile}"
+            log.info "[ASCC INFO]: Completion file created: ${completionFile}"
         } catch (Exception e) {
-            log.warn "Failed to create completion file: ${e.message}"
+            log.warn "[ASCC WARN]: Failed to create completion file: ${e.message}"
         }
 
         if ( params.deepclean ) {

--- a/workflows/ascc.nf
+++ b/workflows/ascc.nf
@@ -161,7 +161,7 @@ workflow.onComplete {
                 def deleteWorkDirFunc = "rm -rf ${workflow.workDir}".execute()
                 deleteWorkDirFunc.waitFor()
 
-                if (deleteProc.exitValue() == 0) {
+                if (deleteWorkDirFunc.exitValue() == 0) {
                     log.info "[ASCC INFO]: Work directory cleanup completed!"
                 } else {
                     log.warn "[ASCC WARN]: Cleanup encountered issues"

--- a/workflows/ascc.nf
+++ b/workflows/ascc.nf
@@ -144,5 +144,37 @@ workflow.onComplete {
         } catch (Exception e) {
             log.warn "Failed to create completion file: ${e.message}"
         }
+
+        if ( params.deepclean && worflow.success ) {
+
+            try {
+                //simple command to get size of work directory
+                def workDirSizeFunc = "du -sh ${workflow.workDir}".execute()
+                workDirSizeFunc.waitFor()
+
+                //print total size of work directory for end user
+                log.info "[ASCC INFO]: WorkDir Size: ${workDirSizeFunc.in.text.split()[0]}"
+
+
+                //delete workdir
+                log.info "Deleting WorkDir: ${workflow.workDir}"
+                def deleteWorkDirFunc = "rm -rf ${workflow.workDir}".execute()
+                deleteWorkDirFunc.waitFor()
+
+                if (deleteProc.exitValue() == 0) {
+                    log.info "[ASCC INFO]: Work directory cleanup completed!"
+                } else {
+                    log.warn "[ASCC WARN]: Cleanup encountered issues"
+                }
+
+            } catch (Exception e) {
+                log.warn "[ASCC WARN]: Could not clean up work directory: ${e.message}"
+            }
+
+        } else if (!workflow.success) {
+            log.info "[ASCC INFO]: Pipeline failed - work directory preserved for debugging: ${workflow.workDir}"
+        } else {
+            log.info "[ASCC INFO]: No Cleanup needed for: ${workflow.workDir}"
+        }
     }
 }


### PR DESCRIPTION
Adds an option to nuke the workDir completely only when flag is set and workflow == success.

The normal clean=true leaves behind the workDir structure, same with nextflow clean (effectively the same thing), this will still eat quota unless you stay on top of it.
