### PR TITLE
Fix integer overflow by using toLong for scaffold size

### DIFF
--- a/subworkflows/local/generate_genomes/main.nf
+++ b/subworkflows/local/generate_genomes/main.nf
@@ -44,7 +44,7 @@ workflow GENERATE_GENOME {
     ch_versions     = ch_versions.mix( GET_LARGEST_SCAFFOLD.out.versions )
 
     emit:
-    max_scaff_size  = GET_LARGEST_SCAFFOLD.out.scaff_size.toInteger()
+    max_scaff_size  = GET_LARGEST_SCAFFOLD.out.scaff_size.toLong()
     dot_genome      = GNU_SORT.out.sorted
     ref_index       = SAMTOOLS_FAIDX.out.fai
     reference_tuple = to_chromsize


### PR DESCRIPTION
This PR replaces `toInteger()` with `toLong()` for `max_scaff_size` emitted from
`GET_LARGEST_SCAFFOLD`.

This prevents integer overflow for assemblies with scaffolds larger than 2 Gbp,
as noted in issue #206.

Fixes #206