### PR TITLE
docs: document FCS-GX alarm thresholds

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -61,6 +61,7 @@ A text file containing a report of trailing Ns found in the genome. Trailing Ns 
 
 <details markdown="1">
 <summary>Output files</summary>
+
 - `mito_organellar_blast/`
   `*-mitochondrial_genome.contamination_recommendation` - A file that contains the names of sequences that are suspected mitochondrial contaminants in the nuclear DNA assembly, tagged as either "REMOVE" or "Investigate" depending on the BLAST hit alignment length and percentage identity. The file is empty if there are no suspected mitochondrial contaminants.
 </details>


### PR DESCRIPTION
This PR documents the FCS-GX alarm thresholds used by the Autofilter and Check Assembly step,
clarifying when `fcs-gx_alarm_indicator_file.txt` is produced and how it is used to enable
additional inspection (e.g. BlobToolKit).

Closes #125.
