### PR TITLE
Dev2Main - hotfix

### DIFF
--- a/workflows/ascc_genomic.nf
+++ b/workflows/ascc_genomic.nf
@@ -796,10 +796,9 @@ workflow ASCC_GENOMIC {
     //              THIS SHOULD ONLY RUN IF STANDARD CONDITIONALS ARE MET
     //              AND ABNORMAL CONTAMINATION IS FOUND
     RUN_DECONTAMINATE_FASTA(
-        ej_reference_tuple.filter{ meta, file ->
+        ej_reference_tuple.filter { meta, file ->
             params.run_decontaminate_fasta in run_conditionals && params.run_autofilter_assembly == "both"
-            return [[id: meta.id], file]
-        },
+        }.map { meta, file -> [[id: meta.id], file] },
         ch_fcsgx,
         ch_autofilt_fcs_tiara,
         ch_fcsadapt.map{ meta, files ->


### PR DESCRIPTION
Hotfix submitted by @prototaxites to fix an issue where a tuple was filtered and then passed through anyway. This caused the processes to always be run rather than skipped.